### PR TITLE
fix: Add asset to setup.py package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
                              'assets/feature_code_dict.json',
                              'assets/hierarchy.txt',
                              'assets/mordecai_2023-03-28.pt',
-                             'assets/wikipedia-iso-country-codes.txt']}
+                             'assets/wikipedia-iso-country-codes.txt',
+                             'assets/mordecai_2024-06-04.pt']}
 )
 
 


### PR DESCRIPTION
mordecai_2024-06-04.pt is used in geoparser.py and not included in the setup.